### PR TITLE
Update egui to 0.8.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -293,7 +293,8 @@ checksum = "9ea835d29036a4087793836fa931b08837ad5e957da9e23886b29586fb9b6650"
 [[package]]
 name = "egui"
 version = "0.8.0"
-source = "git+https://github.com/emilk/egui?rev=90a0ce969beb96506d5a3e9a012765ae46774969#90a0ce969beb96506d5a3e9a012765ae46774969"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f550e7f51023f5ea92eae420fae368a52927deed22dcbefc7c22c140b02d7b4"
 dependencies = [
  "epaint",
 ]
@@ -311,12 +312,14 @@ dependencies = [
 [[package]]
 name = "emath"
 version = "0.8.0"
-source = "git+https://github.com/emilk/egui?rev=90a0ce969beb96506d5a3e9a012765ae46774969#90a0ce969beb96506d5a3e9a012765ae46774969"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d876a5b910712537191b8d9aa1550a212a62fd2dd6f44f6ca5c671cf89bb841"
 
 [[package]]
 name = "epaint"
 version = "0.8.0"
-source = "git+https://github.com/emilk/egui?rev=90a0ce969beb96506d5a3e9a012765ae46774969#90a0ce969beb96506d5a3e9a012765ae46774969"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9fdb7fdb35896a43ad950a28b5188240cfbd186b22aa50269978575170b73c83"
 dependencies = [
  "ahash",
  "atomic_refcell",
@@ -327,7 +330,8 @@ dependencies = [
 [[package]]
 name = "epi"
 version = "0.8.0"
-source = "git+https://github.com/emilk/egui?rev=90a0ce969beb96506d5a3e9a012765ae46774969#90a0ce969beb96506d5a3e9a012765ae46774969"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e358eaf8b9898aa366bed1c0645dd439f272341e5cd1404c8a6a604e544ee065"
 dependencies = [
  "egui",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -292,13 +292,10 @@ checksum = "9ea835d29036a4087793836fa931b08837ad5e957da9e23886b29586fb9b6650"
 
 [[package]]
 name = "egui"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e53b7f113b52fa8146de4f18ec93c3fb5c92250b970ef8f503372af5d737379"
+version = "0.8.0"
+source = "git+https://github.com/emilk/egui?rev=90a0ce969beb96506d5a3e9a012765ae46774969#90a0ce969beb96506d5a3e9a012765ae46774969"
 dependencies = [
- "ahash",
- "atomic_refcell",
- "rusttype",
+ "epaint",
 ]
 
 [[package]]
@@ -306,9 +303,33 @@ name = "egui_winit_platform"
 version = "0.3.0"
 dependencies = [
  "clipboard",
- "egui",
+ "epi",
  "webbrowser",
  "winit",
+]
+
+[[package]]
+name = "emath"
+version = "0.8.0"
+source = "git+https://github.com/emilk/egui?rev=90a0ce969beb96506d5a3e9a012765ae46774969#90a0ce969beb96506d5a3e9a012765ae46774969"
+
+[[package]]
+name = "epaint"
+version = "0.8.0"
+source = "git+https://github.com/emilk/egui?rev=90a0ce969beb96506d5a3e9a012765ae46774969#90a0ce969beb96506d5a3e9a012765ae46774969"
+dependencies = [
+ "ahash",
+ "atomic_refcell",
+ "emath",
+ "rusttype",
+]
+
+[[package]]
+name = "epi"
+version = "0.8.0"
+source = "git+https://github.com/emilk/egui?rev=90a0ce969beb96506d5a3e9a012765ae46774969#90a0ce969beb96506d5a3e9a012765ae46774969"
+dependencies = [
+ "egui",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ license = "MIT OR Apache-2.0"
 readme = "README.md"
 
 [dependencies]
-epi = { git = "https://github.com/emilk/egui", rev = "90a0ce969beb96506d5a3e9a012765ae46774969" }
+epi = "0.8.0"
 winit = "0.24"
 clipboard = { version = "0.5.0", optional = true}
 webbrowser = { version = "0.5.5", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ license = "MIT OR Apache-2.0"
 readme = "README.md"
 
 [dependencies]
-egui = "0.6"
+epi = { git = "https://github.com/emilk/egui", rev = "90a0ce969beb96506d5a3e9a012765ae46774969" }
 winit = "0.24"
 clipboard = { version = "0.5.0", optional = true}
 webbrowser = { version = "0.5.5", optional = true }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,15 +9,12 @@ use epi::egui;
 
 #[cfg(feature = "clipboard")]
 use clipboard::{ClipboardContext, ClipboardProvider};
-use egui::Key;
-use egui::{
+use epi::egui::{
     math::{pos2, vec2},
-    CtxRef,
+    paint::ClippedShape,
+    CtxRef, Key,
 };
-use winit::event::VirtualKeyCode::*;
-use winit::event::WindowEvent::*;
-use winit::event::{Event, ModifiersState, VirtualKeyCode};
-use epi::egui::paint::ClippedShape;
+use winit::event::{Event, ModifiersState, VirtualKeyCode, VirtualKeyCode::*, WindowEvent::*};
 
 /// Configures the creation of the `Platform`.
 pub struct PlatformDescriptor {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,8 @@
 //! A basic usage example can be found [here](https://github.com/hasenbanck/egui_example).
 #![warn(missing_docs)]
 
+use epi::egui;
+
 #[cfg(feature = "clipboard")]
 use clipboard::{ClipboardContext, ClipboardProvider};
 use egui::Key;
@@ -15,6 +17,7 @@ use egui::{
 use winit::event::VirtualKeyCode::*;
 use winit::event::WindowEvent::*;
 use winit::event::{Event, ModifiersState, VirtualKeyCode};
+use epi::egui::paint::ClippedShape;
 
 /// Configures the creation of the `Platform`.
 pub struct PlatformDescriptor {
@@ -25,7 +28,7 @@ pub struct PlatformDescriptor {
     /// HiDPI scale factor.
     pub scale_factor: f64,
     /// Egui font configuration.
-    pub font_definitions: egui::paint::fonts::FontDefinitions,
+    pub font_definitions: egui::FontDefinitions,
     /// Egui style configuration.
     pub style: egui::Style,
 }
@@ -70,7 +73,7 @@ impl Platform {
         context.set_style(descriptor.style);
 
         let mut raw_input = egui::RawInput::default();
-        raw_input.pixels_per_point = Some(descriptor.font_definitions.pixels_per_point);
+        raw_input.pixels_per_point = Some(context.pixels_per_point());
 
         raw_input.screen_rect = Some(egui::Rect::from_min_size(
             Default::default(),
@@ -196,7 +199,7 @@ impl Platform {
     }
 
     /// Ends the frame. Returns what has happened as `Output` and gives you the draw instructions as `PaintJobs`.
-    pub fn end_frame(&mut self) -> (egui::Output, Vec<(egui::Rect, egui::PaintCmd)>) {
+    pub fn end_frame(&mut self) -> (egui::Output, Vec<ClippedShape>) {
         // otherwise the below line gets flagged by clippy if both clipboard and webbrowser features are disabled
         #[allow(clippy::let_and_return)]
         let parts = self.context.end_frame();


### PR DESCRIPTION
This update comes alongside https://github.com/hasenbanck/egui_wgpu_backend/pull/7 to update egui and everything else.