### PR TITLE
Fix the unwrap of a None value

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ license = "MIT OR Apache-2.0"
 readme = "README.md"
 
 [dependencies]
-egui = "0.9"
+egui = "0.10"
 winit = "0.24"
 clipboard = { version = "0.5.0", optional = true}
 webbrowser = { version = "0.5.5", optional = true }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -211,6 +211,8 @@ impl Platform {
     /// Starts a new frame by providing a new `Ui` instance to write into.
     pub fn begin_frame(&mut self) {
         self.context.begin_frame(self.raw_input.take());
+        // Reset the tooked pixels_per_point (our scale_factor)
+        self.raw_input.pixels_per_point = Some(self.scale_factor as f32);
     }
 
     /// Ends the frame. Returns what has happened as `Output` and gives you the draw instructions as `PaintJobs`.


### PR DESCRIPTION
So now `egui::RawInput::take` takes the value of `pixels_per_point` too, and since the platform uses event-based notification, then we are screwed if we don't receive another event.

Luckily, we store the last seen `scale_factor`/`pixels_per_point` on the platform, so it was just a matter of moving it into the empty space that was left.