### PR TITLE
Fix minimize on Windows

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,6 +12,7 @@ use egui::{
     CtxRef,
 };
 use egui::{paint::ClippedShape, Key};
+use winit::dpi::PhysicalSize;
 use winit::event::VirtualKeyCode::*;
 use winit::event::WindowEvent::*;
 use winit::event::{Event, ModifiersState, VirtualKeyCode};
@@ -101,6 +102,10 @@ impl Platform {
                 window_id: _window_id,
                 event,
             } => match event {
+                Resized(PhysicalSize {
+                    width: 0,
+                    height: 0,
+                }) => {}
                 Resized(physical_size) => {
                     self.raw_input.screen_rect = Some(egui::Rect::from_min_size(
                         Default::default(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -102,6 +102,10 @@ impl Platform {
                 window_id: _window_id,
                 event,
             } => match event {
+                // Resize with 0 width and height is used by winit to signal a minimize event on Windows.
+                // See: https://github.com/rust-windowing/winit/issues/208
+                // There is nothing to do for minimize events, so it is ignored here. This solves an issue where
+                // egui window positions would be changed when minimizing on Windows.
                 Resized(PhysicalSize {
                     width: 0,
                     height: 0,


### PR DESCRIPTION
- To start, this just ignores the special `Resized(0, 0)` overload that winit uses on Windows to notify a minimize event. See https://github.com/rust-windowing/winit/issues/208
- This fixes a bug on Windows where minimizing adjusts all of the egui window positions.