### PR TITLE
Derive Debug and Default on PlatformDesriptor

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,6 +18,7 @@ use winit::event::WindowEvent::*;
 use winit::event::{Event, ModifiersState, VirtualKeyCode};
 
 /// Configures the creation of the `Platform`.
+#[derive(Debug, Default)]
 pub struct PlatformDescriptor {
     /// Width of the window in physical pixel.
     pub physical_width: u32,


### PR DESCRIPTION
This can simplify the creation of `PlatformDescriptor` slightly in some cases. E.g.

```rust
let platform = Platform::new(PlatformDescriptor {
    physical_width,
    physical_height,
    scale_factor,
    ..PlatformDescriptor::default()
});
```

It is no longer necessary to provide all fields explicitly. As seen in the example repo: https://github.com/hasenbanck/egui_example/blob/b57c674088c1c24b42ec66b52d96e3d0cfb8ef06/src/main.rs#L81-L87