### PR TITLE
Replace clipboard with copypasta

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,5 +12,9 @@ readme = "README.md"
 [dependencies]
 egui = "0.12"
 winit = "0.25"
-clipboard = { version = "0.5.0", optional = true}
+copypasta = { version = "0.7.1", optional = true }
 webbrowser = { version = "0.5.5", optional = true }
+
+[features]
+default = []
+clipboard = ["copypasta"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,7 +6,7 @@
 #![warn(missing_docs)]
 
 #[cfg(feature = "clipboard")]
-use clipboard::{ClipboardContext, ClipboardProvider};
+use copypasta::{ClipboardContext, ClipboardProvider};
 use egui::{
     math::{pos2, vec2},
     CtxRef,


### PR DESCRIPTION
- Should be fully backward-compatible with the `clipboard` feature.
- This updates some transitive dependencies, and adds support for clipboard on Wayland.

```
$ cargo update
    Updating crates.io index
    Removing clipboard v0.5.0
    Updating clipboard-win v2.2.0 -> v3.1.1
      Adding copypasta v0.7.1
      Adding lazy-bytes-cast v5.0.1
      Adding smithay-clipboard v0.6.3
    Updating x11-clipboard v0.3.3 -> v0.5.2
    Updating xcb v0.8.2 -> v0.9.0
```