### PR TITLE
Allow default fonts to be replaced

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,11 +10,12 @@ license = "MIT OR Apache-2.0"
 readme = "README.md"
 
 [dependencies]
-egui = "0.12"
+egui = { version = "0.12", default-features = false, features = ["single_threaded"] }
 winit = "0.25"
 copypasta = { version = "0.7.1", optional = true }
 webbrowser = { version = "0.5.5", optional = true }
 
 [features]
-default = []
+default = ["default_fonts"]
 clipboard = ["copypasta"]
+default_fonts = ["egui/default_fonts"]


### PR DESCRIPTION
I'm not a fan of this, but it appears to be the only way to fully replace the default fonts. It matches the approach used by `egui_glium` and `egui_web`.

This PR allows a downstream crate to disable default-features when it wants to build without the fonts normally included in `egui`.