### PR TITLE
Fix modifier state not being updated in raw_input

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -170,7 +170,10 @@ impl Platform {
                 CursorLeft { .. } => {
                     self.raw_input.events.push(egui::Event::PointerGone);
                 }
-                ModifiersChanged(input) => self.modifier_state = *input,
+                ModifiersChanged(input) => {
+                    self.modifier_state = *input;
+                    self.raw_input.modifiers = winit_to_egui_modifiers(*input);
+                }
                 KeyboardInput { input, .. } => {
                     if let Some(virtual_keycode) = input.virtual_keycode {
                         let pressed = input.state == winit::event::ElementState::Pressed;


### PR DESCRIPTION
Hi!

This adds a line to the response to `ModifiersChanged` event that also updates the state of modifiers in `raw_input.modifiers`.

Fixes the issue that some egui widgets did not work properly. For example, `DragValue` uses slower speed if shift is pressed while dragging.