### PR TITLE
Disable winit default features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ readme = "README.md"
 
 [dependencies]
 egui = { version = "0.13", default-features = false, features = ["single_threaded"] }
-winit = "0.25"
+winit = { version = "0.25", default-features = false }
 copypasta = { version = "0.7", optional = true }
 webbrowser = { version = "0.5", optional = true }
 


### PR DESCRIPTION
This helps when targeting linux as you can drop the (often out of date) wayland stack.