### PR TITLE
Add a way to access the inner raw input

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -314,6 +314,12 @@ impl Platform {
     pub fn context(&self) -> CtxRef {
         self.context.clone()
     }
+
+    /// Returns a mutable reference to the raw input that will be passed to egui
+    /// the next time [`Self::begin_frame`] is called
+    pub fn raw_input_mut(&mut self) -> &mut egui::RawInput {
+        &mut self.raw_input
+    }
 }
 
 /// Translates winit to egui keycodes.


### PR DESCRIPTION
For some advanced use cases (like my node editor for _Blackjack_, see gif below), it is desirable to have very precise control over the raw input that is fed to egui, so I added a method to fetch it mutably. 

For my specific case, for instance, I had to override the value of `pixels_per_point` because it didn't correspond to the window scale, but I'm sure there are other use cases for this, like simulating mouse / keyboard events without having to "impersonate" winit via `handle_event`.


https://user-images.githubusercontent.com/7241990/150692104-aa68d4ad-e1c7-423a-897e-565fe989696a.mp4



 