### PR TITLE
Upgrade to egui 0.18 (and rustfmt)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ license = "MIT OR Apache-2.0"
 readme = "README.md"
 
 [dependencies]
-egui = { version = "0.17", default-features = false, features = ["single_threaded"] }
+egui = { version = "0.18", default-features = false }
 winit = { version = "0.26", default-features = false }
 copypasta = { version = "0.7", optional = true }
 webbrowser = { version = "0.5", optional = true }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,7 +16,7 @@ use egui::{
 };
 use winit::{
     dpi::PhysicalSize,
-    event::{Event, ModifiersState, VirtualKeyCode, VirtualKeyCode::*, WindowEvent::*, TouchPhase},
+    event::{Event, ModifiersState, TouchPhase, VirtualKeyCode, VirtualKeyCode::*, WindowEvent::*},
     window::CursorIcon,
 };
 
@@ -181,7 +181,7 @@ impl Platform {
                             self.device_indices.insert(touch.device_id, device_id);
                             self.next_device_index += 1;
                             device_id
-                        },
+                        }
                     };
                     let egui_phase = match touch.phase {
                         TouchPhase::Started => egui::TouchPhase::Start,
@@ -193,7 +193,7 @@ impl Platform {
                     let force = match touch.force {
                         Some(winit::event::Force::Calibrated { force, .. }) => force as f32,
                         Some(winit::event::Force::Normalized(force)) => force as f32,
-                        None => 0.0f32 // hmmm, egui can't differentiate unsupported from zero pressure
+                        None => 0.0f32, // hmmm, egui can't differentiate unsupported from zero pressure
                     };
 
                     self.raw_input.events.push(egui::Event::Touch {
@@ -201,7 +201,7 @@ impl Platform {
                         id: egui::TouchId(touch.id),
                         phase: egui_phase,
                         pos: pointer_pos,
-                        force
+                        force,
                     });
 
                     // Currently Winit doesn't emulate pointer events based on
@@ -217,18 +217,23 @@ impl Platform {
                     match touch.phase {
                         TouchPhase::Started => {
                             self.touch_pointer_pressed += 1;
-                        },
+                        }
                         TouchPhase::Ended | TouchPhase::Cancelled => {
-                            self.touch_pointer_pressed = match self.touch_pointer_pressed.checked_sub(1) {
+                            self.touch_pointer_pressed = match self
+                                .touch_pointer_pressed
+                                .checked_sub(1)
+                            {
                                 Some(count) => count,
                                 None => {
                                     eprintln!("Pointer emulation error: Unbalanced touch start/stop events from Winit");
                                     0
                                 }
                             };
-                        },
+                        }
                         TouchPhase::Moved => {
-                            self.raw_input.events.push(egui::Event::PointerMoved(pointer_pos));
+                            self.raw_input
+                                .events
+                                .push(egui::Event::PointerMoved(pointer_pos));
                         }
                     }
 
@@ -528,6 +533,7 @@ fn egui_to_winit_cursor_icon(icon: egui::CursorIcon) -> Option<winit::window::Cu
         ZoomIn => Some(CursorIcon::ZoomIn),
         ZoomOut => Some(CursorIcon::ZoomOut),
         None => Option::None,
+        _ => Option::None,
     }
 }
 


### PR DESCRIPTION
Two changes in egui 0.18 affected this crate:
- The `single_threaded` feature was removed as the crate is now always thread safe.
- `egui::CursorIcon` got some more variants. I did not implement any of the new variants, but added a fallback. I think that this might be a helpful compatibility aid for future upgrades.

Additionally, my editor rustfmt'd the file. If you'd like, I can back out that change, but I think it's a helpful standard to push for.