### PR TITLE
Update to egui 0.21 and winit 0.28

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,8 +10,8 @@ license = "MIT OR Apache-2.0"
 readme = "README.md"
 
 [dependencies]
-egui = { version = "0.20", default-features = false }
-winit = { version = "0.27", default-features = false }
+egui = { version = "0.21", default-features = false }
+winit = { version = "0.28" }
 copypasta = { version = "0.8", optional = true }
 webbrowser = { version = "0.8", optional = true }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -323,6 +323,7 @@ impl Platform {
                                         key,
                                         pressed,
                                         modifiers: winit_to_egui_modifiers(self.modifier_state),
+                                        repeat: false,
                                     });
                                 }
                             }


### PR DESCRIPTION
Closes #47.

As mentioned in the issue, we have to turn on default features for winit to get it to compile. Personally I think this is fine, but I'm not sure if everyone's fine by that.