### PR TITLE
bump egui to 0.27

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ license = "MIT OR Apache-2.0"
 readme = "README.md"
 
 [dependencies]
-egui = { version = "0.26", default-features = false }
+egui = { version = "0.27", default-features = false }
 winit = { version = "0.29" }
 copypasta = { version = "0.8", optional = true }
 webbrowser = { version = "0.8", optional = true }


### PR DESCRIPTION
Bump `egui` dependency to 0.27.

Did not bump `winit` yet as there are breaking changes.

Did not extensively test.