### PR TITLE
Release 0.26 with egui 0.31

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.26.0] - 2025-03-29
+
+- Target egui 0.31
+
 ## [0.25.0] - 2024-12-28
 
 - Target egui 0.30

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "egui_winit_platform"
-version = "0.25.0"
+version = "0.26.0"
 authors = ["Nils Hasenbanck <nils@hasenbanck.de>"]
 edition = "2018"
 description = "Platform code to use egui with winit."
@@ -10,7 +10,7 @@ license = "MIT OR Apache-2.0"
 readme = "README.md"
 
 [dependencies]
-egui = { version = "0.30", default-features = false }
+egui = { version = "0.31", default-features = false }
 winit = { version = "0.30" }
 copypasta = { version = "^0.10", optional = true }
 webbrowser = { version = "^1.0", optional = true }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,21 +41,25 @@ pub struct PlatformDescriptor {
 
 #[cfg(feature = "webbrowser")]
 fn handle_links(output: &egui::PlatformOutput) {
-    if let Some(open_url) = &output.open_url {
-        // This does not handle open_url.new_tab
-        // webbrowser does not support web anyway
-        if let Err(err) = webbrowser::open(&open_url.url) {
-            eprintln!("Failed to open url: {}", err);
+    for command in &output.commands {
+        if let egui::OutputCommand::OpenUrl(open_url) = command {
+            // This does not handle open_url.new_tab
+            // webbrowser does not support web anyway
+            if let Err(err) = webbrowser::open(&open_url.url) {
+                eprintln!("Failed to open url: {}", err);
+            }
         }
     }
 }
 
 #[cfg(feature = "clipboard")]
 fn handle_clipboard(output: &egui::PlatformOutput, clipboard: Option<&mut ClipboardContext>) {
-    if !output.copied_text.is_empty() {
-        if let Some(clipboard) = clipboard {
-            if let Err(err) = clipboard.set_contents(output.copied_text.clone()) {
-                eprintln!("Copy/Cut error: {}", err);
+    if let Some(clipboard) = clipboard {
+        for command in &output.commands {
+            if let egui::OutputCommand::CopyText(copied_text) = command {
+                if let Err(err) = clipboard.set_contents(copied_text.clone()) {
+                    eprintln!("Copy/Cut error: {}", err);
+                }
             }
         }
     }


### PR DESCRIPTION
This updates egui to the latest, and version bumps to prep for release.

The `copied_text` and `open_url` members on `PlatformOutput` are now deprecated, and will be replaced with the newer list of `commands`. These changes switch away from the deprecated versions.